### PR TITLE
Use dlv instead of object-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm i --save redux-watch
 `watch(getState [, objectPath [, comparison]])` -> `function`
 
 - `getState`: A `function` that is used to return the state. Also useful in conjunction with selectors.
-- `objectPath`: An **optional** `string` or `Array` that represents the path in an object. Uses [object-path](https://www.npmjs.com/package/object-path) ([mariocasciaro/object-path](https://github.com/mariocasciaro/object-path)) for value extraction.
+- `objectPath`: An **optional** `string` or `Array` that represents the path in an object. Uses [dlv](https://www.npmjs.com/package/dlv) ([developit/dlv](https://github.com/developit/dlv)) for value extraction.
 - `comparison`: An **optional** function to pass for comparison of the fields. Defaults to strict equal comparison (`===`).
 
 ## Example

--- a/index.js
+++ b/index.js
@@ -1,8 +1,12 @@
 'use strict'
-var getValue = require('object-path').get
+var dlv = require('dlv')
 
 function defaultCompare (a, b) {
   return a === b
+}
+
+function getValue (state, objectPath) {
+  return objectPath ? dlv(state, objectPath) : state
 }
 
 function watch (getState, objectPath, compare) {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "unit": "tape test/*.js | tap-spec"
   },
   "dependencies": {
-    "object-path": "^0.9.2"
+    "dlv": "^1.1.1"
   },
   "devDependencies": {
     "redux": "^3.0.5",


### PR DESCRIPTION
[dlv](https://github.com/developit/dlv) ([npm page](https://www.npmjs.com/package/dlv)) is less than 128 bytes gzipped while object-path is over 1KB.